### PR TITLE
Fix start script to use http.server module for Python 3 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Sample React Editor based on SVGEDit",
   "main": "dist/editor.js",
   "scripts": {
-    "start": "python -m SimpleHTTPServer",
+    "start": "python -m http.server",
     "build": "npx webpack --mode production",
     "build-dev": "npx webpack --mode development --watch",
     "build-doc": "./node_modules/.bin/esdoc .esdoc.json",


### PR DESCRIPTION
**Description:**

The current start script in package.json uses the SimpleHTTPServer module, which is only available in Python 2. This causes the server to fail on systems with Python 3, resulting in an error. This pull request updates the start script to use the http.server module, which is the Python 3 equivalent, ensuring compatibility and resolving the issue.

### Error Before Change:

```bash

> @svg-edit/svgedit-react@0.1.0 start /home/kali/code/extra/svg-edit-react-test
> python -m SimpleHTTPServer

/usr/bin/python: No module named SimpleHTTPServer

 ELIFECYCLE  Command failed with exit code 1.

```

### Changes made:

- Updated the start script in package.json from "python -m SimpleHTTPServer" to "python -m http.server".

### Example:

#### Before:

```json

"scripts": {
  "start": "python -m SimpleHTTPServer"
}
```

#### After:

```json

"scripts": {
  "start": "python -m http.server"
}

```

### Impact:

This change will ensure the development server starts correctly on systems with Python 3, providing a smoother development experience.